### PR TITLE
Update config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ def getEnvVariable(name):
 
 
 POSTGRES_HOST = getEnvVariable("POSTGRES_HOST")
-POSTGRES_PORT = getEnvVariable("POSTGRES_PORT")
+POSTGRES_PORT = getEnvVariable("POSTGRES_PORT", 5433)
 POSTGRES_USER = getEnvVariable("POSTGRES_USER")
 POSTGRES_PW = getEnvVariable("POSTGRES_PW")
 POSTGRES_DB = getEnvVariable("POSTGRES_DB")


### PR DESCRIPTION
POSTGRES_PORT = getEnvVariable("POSTGRES_PORT", 5433)
if we are deploying all services in one host then 5432 will be used by another service